### PR TITLE
Fixed error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MPI Tutorial
 ============
 
-This is the static webpage and code for mpitutorial.com. View mpitutorial.com/about/ for guidelines on how to contribute tutorials, or feel free to open a pull request to fix any issues.
+This is the static webpage and code for [mpitutorial](mpitutorial.com). View [about](mpitutorial.com/about/) for guidelines on how to contribute tutorials, or feel free to open a pull request to fix any issues.
 
-For those that simply wish to view MPI code examples without the site, browse the tutorials/*/code directories of the various tutorials. The tutorials/run.py script provides the ability to build and run all tutorial code.
+For those that simply wish to view MPI code examples without the site, browse the [tutorials/*/code](https://github.com/Cole9712/mpitutorial/tree/gh-pages/tutorials) directories of the various tutorials. The [run.py](https://github.com/Cole9712/mpitutorial/blob/gh-pages/tutorials/run.py) script provides the ability to build and run all tutorial code.
+
+


### PR DESCRIPTION
The original document had a mix of text and URLs that made it difficult for the reader to read, so I turned all the web links into clickable jump buttons to make the links clearer